### PR TITLE
bugfix: Fix pkg-lp-to-* scripts

### DIFF
--- a/pkg-lp-to-ubuntu-openstack-dev
+++ b/pkg-lp-to-ubuntu-openstack-dev
@@ -31,7 +31,7 @@ rm -rf ${orig_dir}/${pkg}/.git*
 
 git init -b master
 git add *
-git add ./.*
+find ${orig_dir}/${pkg}/ -maxdepth 1 -name '.*' ! -name '.' -exec git add {} +
 git commit -a -m "Initial import from Launchpad"
 
 git checkout --orphan upstream

--- a/pkg-lp-to-ubuntu-server-dev
+++ b/pkg-lp-to-ubuntu-server-dev
@@ -31,7 +31,7 @@ rm -rf ${orig_dir}/${pkg}/.git*
 
 git init
 git add *
-git add */.*
+find ${orig_dir}/${pkg}/ -maxdepth 1 -name '.*' ! -name '.' -exec git add {} +
 git commit -a -m "Initial import from Launchpad"
 
 git checkout --orphan upstream


### PR DESCRIPTION
git ./.* was trying to add dirs . and .. to git which caused script to fail. Fixed by replacing with `find` and ignoring . in the search.